### PR TITLE
[Fix] Options are now properly passed to HTMLProcessor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var through = require('through2')
   , HTMLProcessor = require('htmlprocessor')
   , PluginError = gutil.PluginError;
 
-module.exports = function(fileName, options) {
+module.exports = function(options) {
 
   var processor = new HTMLProcessor(options);
 


### PR DESCRIPTION
Remove name parameter in module.exports(), name was causing a shift in the parameters, moreover name is unused
